### PR TITLE
Passing token as header

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install
 npm start
 ```
 
-4. Open your browser on the specified address (normally http://localhost:9966/)
+4. Open your browser on the specified address (normally http://localhost:1234/index.html)
 
 
 ## Contributing

--- a/src/providers/dataProvider.js
+++ b/src/providers/dataProvider.js
@@ -3,7 +3,14 @@
 const token = '21ca3e689e43e2ec61a923646f8ed4b4ca7ad919';
 
 export async function isValidRepo(user, repo) {
-  const fetchResult = await fetch(`https://api.github.com/repos/${user}/${repo}?access_token=${token}`);
+  const options = {
+    headers: new Headers({ Authorization: `token ${token}` }),
+  };
+
+  const fetchResult = await fetch(
+    `https://api.github.com/repos/${user}/${repo}`,
+    options,
+  );
 
   return fetchResult.ok;
 }


### PR DESCRIPTION
Passing token as header as instructed by github: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/#changes-to-make